### PR TITLE
Support Typst 0.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This is an unofficial Typst template for the International Astronautical Congres
 
 ## Usage
 
+> [!WARNING]
+> These commands may not work if this template is not yet merged into the official [Typst package/template registry](https://github.com/typst/packages).
+> To use the latest version of this template, consider cloning this repository and using it as a local package.
+
 To initialize a project with this template, run the following command:
 
 ```bash
@@ -13,7 +17,7 @@ typst init @preview/stellar-iac
 Or, you can manually add the following line at the beginning of your Typst file:
 
 ```typst
-#import "@preview/stellar-iac:0.4.1": project
+#import "@preview/stellar-iac:0.5.0": project
 ```
 
 The `project` function exported by this template has the following named arguments:

--- a/lib.typ
+++ b/lib.typ
@@ -21,7 +21,7 @@
       ],
       align(right)[
         Page
-        #counter(page).display(
+        #context counter(page).display(
           "1 of 1",
           both: true,
         )

--- a/lib.typ
+++ b/lib.typ
@@ -44,27 +44,37 @@
 
   // Authors
   align(center)[
-    #authors.enumerate(start: 1).map(ia => [
-      #let (index, author) = ia
-      #let author_key = numbering("a", index)
-      #set text(weight: "bold")
-      #box[#author.name#super(author_key)#if author.at("corresponding", default: false) {
-          sym.ast.basic
-        }]]).join(", ")
+    #(
+      authors
+        .enumerate(start: 1)
+        .map(ia => [
+          #let (index, author) = ia
+          #let author_key = numbering("a", index)
+          #set text(weight: "bold")
+          #box[#author.name#super(author_key)#if author.at("corresponding", default: false) {
+              sym.ast.basic
+            }]])
+        .join(", ")
+    )
     #v(1.3em, weak: true)
   ]
 
   // Author affiliations
   align(left)[
-    #authors.enumerate(start: 1).map(ia => [
-      #let (index, author) = ia
-      #let author_key = numbering("a", index)
-      #set text(style: "italic")
-      #let org = organizations.find(o => o.name == author.affiliation)
-      #super(author_key) #org.display#if author.email != none {
-        [, #text(style: "normal",underline[#link("mailto:" + author.email)])]
-      }
-    ]).join(linebreak())
+    #(
+      authors
+        .enumerate(start: 1)
+        .map(ia => [
+          #let (index, author) = ia
+          #let author_key = numbering("a", index)
+          #set text(style: "italic")
+          #let org = organizations.find(o => o.name == author.affiliation)
+          #super(author_key) #org.display#if author.email != none {
+            [, #text(style: "normal", underline[#link("mailto:" + author.email)])]
+          }
+        ])
+        .join(linebreak())
+    )
     #linebreak()
     #sym.ast.basic Corresponding Author
   ]

--- a/lib.typ
+++ b/lib.typ
@@ -131,22 +131,19 @@
     v(-0.45 * measure(2 * a).width)
   }
 
-  // Figure show rule
-  show figure.where(kind: image): set figure(supplement: [Fig.])
-  show figure.where(kind: image): it => align(center)[
+  // Figure show rules
+  set figure.caption(separator: [. ])
+  show figure: it => align(center)[
     #v(0.65em)
-    #block(below: 0.65em)[#it.body]
-    #it.supplement #it.counter.display(it.numbering). #it.caption.body
+    #it
     #v(0.65em)
   ]
 
-  // Table show rule
-  show figure.where(kind: table): it => align(center)[
-    #v(0.65em)
-    #it.supplement #it.counter.display(it.numbering). #it.caption.body
-    #block(above: 0.65em)[#it.body]
-    #v(0.65em)
-  ]
+  // Image show rules
+  show figure.where(kind: image): set figure(supplement: [Fig.])
+
+  // Table show rules
+  show figure.where(kind: table): set figure.caption(position: top)
 
   set table(stroke: (x, y) => (
     left: 0pt,

--- a/lib.typ
+++ b/lib.typ
@@ -161,7 +161,7 @@
     bottom: 1.5pt,
   ))
 
-  show par: set block(spacing: 0.65em)
+  set par(spacing: 0.65em)
   set par(justify: true, first-line-indent: 0.5cm)
   show: columns.with(2, gutter: 1.3em)
   set math.equation(numbering: "(1)")

--- a/typst.toml
+++ b/typst.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stellar-iac"
-version = "0.4.1"
-compiler = "0.11.1"
+version = "0.5.0"
+compiler = "0.13.1"
 entrypoint = "lib.typ"
 authors = [
     "Shunichiro Nomura <@shunichironomura>",


### PR DESCRIPTION
This PR contains changes to support the latest Typst version 0.13.1:
- Use context statement
- Update show/set rules for figures to support `scope: "parent"`
